### PR TITLE
Example showing basic CRUD operations

### DIFF
--- a/example_crud.py
+++ b/example_crud.py
@@ -2,11 +2,37 @@
 
 import etesync as api
 
+# The EtesyncCRUD class exposes methods for each of the CRUD operations
+# (Create, Retrieve, Update and Delete) and for sync with the server.
+# It handles only one calendar
+
+# The class is initialized with user details, authToken and
+# EITHER the encryption password OR the cipher key.
+
+# Intended usage is that a calling program (a CLI) obtains user credentials
+# from terminal input or some secure storage (like a key ring)
+# and then creates an instance of EtesyncCRUD as follows:
+
+# # call with cipher key
+# crud = EtesyncCRUD(email, None, remoteUrl, uid, authToken, cipher_key)
+# # call with encryption password
+# crud = EtesyncCRUD(email, userPassword, remoteUrl, uid, authToken, None)
+
+# The CLI program can then perform CRUD operations by calling
+# crud.create_event, crud.retrieve_event,
+# crud.update_event and crud.delete_event
+
+# The CLI must explicitly call crud.sync when needed. For example:
+# (a) if the server has been updated from another device
+# (b) after any CRUD operation other than Retrieve
+
+# No exception handling is done. That is left to the CLI.
+
 
 class EtesyncCRUD:
     def __init__(self, email, userPassword, remoteUrl, uid, authToken,
                  cipher_key=None):
-        r"""Initialize EtesyncInterface
+        """Initialize
 
         Parameters
         ----------
@@ -23,51 +49,30 @@ class EtesyncCRUD:
             self.etesync.derive_key(userPassword)
         self.journal = self.etesync.get(uid)
         self.calendar = self.journal.collection
-        self.error = None
 
     def create_event(self, event):
-        r"""Create event
+        """Create event
 
         Parameters
         ----------
         event : iCalendar file as a string
         (calendar containing one event to be added)
-
-        Returns
-        -------
-        True if event created
-        False otherwise (Error is stored in self.error)
         """
-        try:
-            ev = api.Event.create(self.journal.collection, event)
-            ev.save()
-            return True
-        except Exception as inst:
-            self.error = inst
-            return False
+        ev = api.Event.create(self.journal.collection, event)
+        ev.save()
 
     def update_event(self, event, uid):
-        r"""Edit event
+        """Edit event
 
         Parameters
         ----------
         event : iCalendar file as a string
         (calendar containing one event to be updated)
         uid : uid of event to be updated
-
-        Returns
-        -------
-        True if event updated
-        False otherwise (Error is stored in self.error)
         """
-        try:
-            ev_for_change = self.calendar.get(uid)
-            ev_for_change.content = event
-            ev_for_change.save()
-            return True
-        except Exception as inst:
-            self.error = inst
-            return False
+        ev_for_change = self.calendar.get(uid)
+        ev_for_change.content = event
+        ev_for_change.save()
 
     def retrieve_event(self, uid):
         r"""Retrieve event by uid
@@ -88,46 +93,25 @@ class EtesyncCRUD:
             return None
 
     def all_events(self):
-        r"""Retrieve all events in calendar
-
+        """Retrieve all events in calendar
 
         Returns
         -------
-        On success returns list of iCalendar files (as strings)
-        Otherwise returns None (Error is stored in self.error)
+        List of iCalendar files (as strings)
         """
-        try:
-            return [E.content for E in self.calendar.list()]
-        except Exception as inst:
-            self.error = inst
-            return None
+        return [E.content for E in self.calendar.list()]
 
     def delete_event(self, uid):
-        r"""Delete event and sync calendar
+        """Delete event and sync calendar
 
         Parameters
         ----------
         uid : uid of event to be deleted
-
-        Returns
-        -------
-        True if event deleted
-        False otherwise (Error is stored in self.error)
         """
-        try:
-            ev_for_deletion = self.calendar.get(uid)
-            ev_for_deletion.delete()
-            return True
-        except Exception as inst:
-            self.error = inst
-            return False
+        ev_for_deletion = self.calendar.get(uid)
+        ev_for_deletion.delete()
 
     def sync(self):
         r"""Sync with server
         """
-        try:
-            self.etesync.sync()
-            return True
-        except Exception as inst:
-            self.error = inst
-            return False
+        self.etesync.sync()

--- a/example_crud.py
+++ b/example_crud.py
@@ -83,14 +83,10 @@ class EtesyncCRUD:
 
         Returns
         -------
-        On success returns iCalendar file (as a string)
-        Otherwise returns None (Error is stored in self.error)
+        iCalendar file (as a string)
         """
-        try:
-            return self.calendar.get(uid).content
-        except Exception as inst:
-            self.error = inst
-            return None
+        return self.calendar.get(uid).content
+
 
     def all_events(self):
         """Retrieve all events in calendar
@@ -99,7 +95,7 @@ class EtesyncCRUD:
         -------
         List of iCalendar files (as strings)
         """
-        return [E.content for E in self.calendar.list()]
+        return [e.content for e in self.calendar.list()]
 
     def delete_event(self, uid):
         """Delete event and sync calendar

--- a/example_crud.py
+++ b/example_crud.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+import etesync as api
+
+
+class EtesyncCRUD:
+    def __init__(self, email, userPassword, remoteUrl, uid, authToken,
+                 cipher_key=None):
+        r"""Initialize EtesyncInterface
+
+        Parameters
+        ----------
+        email : etesync username(email)
+        userPassword : etesync encryption password
+        remoteUrl : url of etesync server
+        uid : uid of calendar
+        authToken : authentication token for etesync server
+        """
+        self.etesync = api.EteSync(email, authToken, remote=remoteUrl)
+        if cipher_key:
+            self.etesync.cipher_key = cipher_key
+        else:
+            self.etesync.derive_key(userPassword)
+        self.journal = self.etesync.get(uid)
+        self.calendar = self.journal.collection
+        self.error = None
+
+    def create_event(self, event):
+        r"""Create event
+
+        Parameters
+        ----------
+        event : iCalendar file as a string
+        (calendar containing one event to be added)
+
+        Returns
+        -------
+        True if event created
+        False otherwise (Error is stored in self.error)
+        """
+        try:
+            ev = api.Event.create(self.journal.collection, event)
+            ev.save()
+            return True
+        except Exception as inst:
+            self.error = inst
+            return False
+
+    def update_event(self, event, uid):
+        r"""Edit event
+
+        Parameters
+        ----------
+        event : iCalendar file as a string
+        (calendar containing one event to be updated)
+        uid : uid of event to be updated
+
+        Returns
+        -------
+        True if event updated
+        False otherwise (Error is stored in self.error)
+        """
+        try:
+            ev_for_change = self.calendar.get(uid)
+            ev_for_change.content = event
+            ev_for_change.save()
+            return True
+        except Exception as inst:
+            self.error = inst
+            return False
+
+    def retrieve_event(self, uid):
+        r"""Retrieve event by uid
+
+        Parameters
+        ----------
+        uid : uid of event to be retrieved
+
+        Returns
+        -------
+        On success returns iCalendar file (as a string)
+        Otherwise returns None (Error is stored in self.error)
+        """
+        try:
+            return self.calendar.get(uid).content
+        except Exception as inst:
+            self.error = inst
+            return None
+
+    def all_events(self):
+        r"""Retrieve all events in calendar
+
+
+        Returns
+        -------
+        On success returns list of iCalendar files (as strings)
+        Otherwise returns None (Error is stored in self.error)
+        """
+        try:
+            return [E.content for E in self.calendar.list()]
+        except Exception as inst:
+            self.error = inst
+            return None
+
+    def delete_event(self, uid):
+        r"""Delete event and sync calendar
+
+        Parameters
+        ----------
+        uid : uid of event to be deleted
+
+        Returns
+        -------
+        True if event deleted
+        False otherwise (Error is stored in self.error)
+        """
+        try:
+            ev_for_deletion = self.calendar.get(uid)
+            ev_for_deletion.delete()
+            return True
+        except Exception as inst:
+            self.error = inst
+            return False
+
+    def sync(self):
+        r"""Sync with server
+        """
+        try:
+            self.etesync.sync()
+            return True
+        except Exception as inst:
+            self.error = inst
+            return False


### PR DESCRIPTION
This example demonstrates all the `CRUD` operations for a single calendar (specified by its `uid`). It does not contain any user interface, but simply defines a class that exposes methods for each of the `CRUD` operations and for `sync` with the server. The class is initialized with user credentials  and either the encryption password or the cipher key. The calling program (a `CLI`) may obtain these parameters from terminal input or some secure storage (like a key ring) and then create an instance of `EtesyncCRUD` as follows.
```
# call with cipher key
crud = EtesyncCRUD(email, None, remoteUrl, uid, authToken, cipher_key)
# call with encryption password
crud = EtesyncCRUD(email, userPassword, remoteUrl, uid, authToken, None)
```
The calling (`CLI`) program can then invoke `crud.create_event`, `crud.retrieve_event`, `crud.update_event`, `crud.delete_event` and `crud.sync` as needed.

Been testing this for a few days now, and seemed to be working fine. But, yesterday after adding/updating some events and syncing from the first machine, I am getting an integrity exception (HMAC mismatch) on the second machine and on an android device. First machine is syncing fine. 

Am I doing something wrong? How do I debug this? How can I revert the server to an older state or rebuild the server data from the cache on one of the machines? Any suggestions would be appreciated. (I might add a `panic` method in `EtesyncCRUD` for something like this.)

PS: I am storing the `cipher_key` as a base64 encoded string and converting it back to bytes for the `init` call.